### PR TITLE
Defanging an IP address

### DIFF
--- a/strings/defanging_an_ip_address.rb
+++ b/strings/defanging_an_ip_address.rb
@@ -31,3 +31,7 @@ end
 address = '1.1.1.1'
 print(defang_i_paddr(address))
 # Output: "1[.]1[.]1[.]1"
+
+address = "255.100.50.0"
+print(defang_i_paddr(address))
+# Output: "255[.]100[.]50[.]0"

--- a/strings/defanging_an_ip_address.rb
+++ b/strings/defanging_an_ip_address.rb
@@ -14,12 +14,20 @@
 
 # @param {String} address
 # @return {String}
-def defang_i_paddr(address); end
+def defang_i_paddr(address)
+  hash_table = {}
+
+  address.chars.each_with_index do |value, index|
+    if value == "."
+      hash_table[index] = "[#{value}]"
+    else
+      hash_table[index] = value
+    end
+  end
+
+  hash_table.values.join
+end
 
 address = '1.1.1.1'
 print(defang_i_paddr(address))
 # Output: "1[.]1[.]1[.]1"
-
-address = '1.1.1.1'
-print(defang_i_paddr(address))
-# Output: "255[.]100[.]50[.]0"

--- a/strings/defanging_an_ip_address.rb
+++ b/strings/defanging_an_ip_address.rb
@@ -1,0 +1,25 @@
+# Given a valid (IPv4) IP address, return a defanged version of
+# that IP address. A defanged IP address replaces every period
+# "." with "[.]".
+
+# Example 1:
+#
+# Input: address = "1.1.1.1"
+# Output: "1[.]1[.]1[.]1"
+
+# Example 2:
+#
+# Input: address = "255.100.50.0"
+# Output: "255[.]100[.]50[.]0"
+
+# @param {String} address
+# @return {String}
+def defang_i_paddr(address); end
+
+address = '1.1.1.1'
+print(defang_i_paddr(address))
+# Output: "1[.]1[.]1[.]1"
+
+address = '1.1.1.1'
+print(defang_i_paddr(address))
+# Output: "255[.]100[.]50[.]0"


### PR DESCRIPTION
Given a valid (IPv4) IP address, return a defanged version of that IP address. A defanged IP address replaces every period "." with "[.]".

```
# Example 1:
#
# Input: address = "1.1.1.1"
# Output: "1[.]1[.]1[.]1"

# Example 2:
#
# Input: address = "255.100.50.0"
# Output: "255[.]100[.]50[.]0"
```