### PR TITLE
Find anagram mappings

### DIFF
--- a/hash_table/find_anagram_mappings.rb
+++ b/hash_table/find_anagram_mappings.rb
@@ -1,0 +1,35 @@
+# Given two lists A and B, and B is an anagram of A. B is an anagram of A
+# means B is made by randomizing the order of the elements in A.
+#
+# We want to find an index mapping P, from A to B. A mapping P[i] =
+# means the ith element in A appears in B at index j.
+#
+# These lists A and B may contain duplicates. If there are multiple answers,
+# output any of them.
+#
+# For example, given
+#
+# A = [12, 28, 46, 32, 50]
+# B = [50, 12, 32, 46, 28]
+#
+# We should return
+# [1, 4, 3, 2, 0]
+# as P[0] = 1 because the 0th element of A appears at B[1], and P[1] = 4
+# because the 1st element of A appears at B[4], and so on.
+#
+# Note:
+#
+# A, B have equal lengths in range [1, 100].
+# A[i], B[i] are integers in range [0, 10^5].
+
+# @param {Integer[]} a
+# @param {Integer[]} b
+# @return {Integer[]}
+def anagram_mappings(a, b)
+
+end
+
+a = [12, 28, 46, 32, 50]
+b = [50, 12, 32, 46, 28]
+puts(anagram_mappings(a, b))
+# Output: [1, 4, 3, 2, 0]

--- a/hash_table/find_anagram_mappings.rb
+++ b/hash_table/find_anagram_mappings.rb
@@ -26,7 +26,9 @@
 # @param {Integer[]} b
 # @return {Integer[]}
 def anagram_mappings(a, b)
-
+  h = {}  
+  b.each_with_index { |v, i| h[v] = i }
+  a.map { |v|  h[v] }  
 end
 
 a = [12, 28, 46, 32, 50]


### PR DESCRIPTION
Given two lists `A` and `B`, and `B` is an anagram of `A`. `B` is an anagram of `A` means `B` is made by randomizing the order of the elements in `A`.

We want to find an index mapping `P`, from `A` to `B`. A mapping `P[i] = j` means the ith element in `A` appears in `B` at index `j`.

These lists `A` and `B` may contain duplicates. If there are multiple answers, output any of them.

For example, given

```
A = [12, 28, 46, 32, 50]
B = [50, 12, 32, 46, 28]
We should return
[1, 4, 3, 2, 0]
as P[0] = 1 because the 0th element of A appears at B[1], and P[1] = 4 because the 1st element of A appears at B[4], and so on.
```

Note:

`A`, `B` have equal lengths in range `[1, 100]`.
`A[i]`, `B[i]` are integers in range `[0, 10^5]`.