### PR TITLE
Find pivot index

### DIFF
--- a/strings/find_pivot_index.rb
+++ b/strings/find_pivot_index.rb
@@ -1,0 +1,76 @@
+# Given an array of integers nums, calculate the pivot index of this array.
+#
+# The pivot index is the index where the sum of all the numbers strictly to the left of the index is equal to the sum of all the numbers strictly to the index's right.
+#
+# If the index is on the left edge of the array, then the left sum is 0 because there are no elements to the left. This also applies to the right edge of the array.
+#
+# Return the leftmost pivot index. If no such index exists, return -1.
+#
+# Example 1:
+#
+# Input: nums = [1,7,3,6,5,6]
+# Output: 3
+# Explanation:
+# The pivot index is 3.
+# Left sum = nums[0] + nums[1] + nums[2] = 1 + 7 + 3 = 11
+# Right sum = nums[4] + nums[5] = 5 + 6 = 11
+#
+# Example 2:
+#
+# Input: nums = [1,2,3]
+# Output: -1
+# Explanation:
+# There is no index that satisfies the conditions in the problem statement.
+#
+# Example 3:
+#
+# Input: nums = [2,1,-1]
+# Output: 0
+# Explanation:
+# The pivot index is 0.
+# Left sum = 0 (no elements to the left of index 0)
+# Right sum = nums[1] + nums[2] = 1 + -1 = 0
+#
+#
+# Constraints:
+#
+# 1 <= nums.length <= 104
+# -1000 <= nums[i] <= 1000
+
+#
+# Approach #1: Prefix Sum
+#
+
+# Complexity analysis
+#
+# Time complexity: O(n)
+# Space complexity: O(1)
+
+# @param {Integer[]} nums
+# @return {Integer}
+def pivot_index(nums)
+  left_sum = 0
+  right_sum = nums.sum
+
+  (0...nums.length).each do |i|
+    right_sum -= nums[i]
+
+    return i if left_sum == right_sum
+
+    left_sum += nums[i]
+  end
+
+  -1
+end
+
+nums = [1, 7, 3, 6, 5, 6]
+puts pivot_index(nums)
+
+nums = [1, 2, 3]
+puts pivot_index(nums)
+
+nums = [2, 1, -1]
+puts pivot_index(nums)
+
+nums = [-1, -1, -1, -1, -1, -1]
+puts pivot_index(nums)


### PR DESCRIPTION
Given an array of integers nums, calculate the pivot index of this array.

The pivot index is the index where the sum of all the numbers strictly to the left of the index is equal to the sum of all the numbers strictly to the index's right.

If the index is on the left edge of the array, then the left sum is 0 because there are no elements to the left. This also applies to the right edge of the array.

Return the leftmost pivot index. If no such index exists, return -1.